### PR TITLE
数据库设计

### DIFF
--- a/design.md
+++ b/design.md
@@ -55,7 +55,7 @@
 | 列名  | 类型          | 备注                                         |
 |-------|---------------|----------------------------------------------|
 | id    |               | 外码 → User                                  |
-| token | string (UUID) | 登录时给一个 token，用于验证身份，登出时删去 |
+| token | UUID          | 登录时给一个 token，用于验证身份，登出时删去 |
 
 ### `Interviewee`
 | 列名                | 类型      | 备注                                                         |
@@ -86,8 +86,8 @@
 | HR_id              | integer | 外码 → User                    |
 | interviewer_id     | integer | 外码 → User                    |
 | interviewee_id     | integer | 外码 → Interviewee             |
-| interviewer_token  | string  | 随机生成 UUID          |
-| interviewee_token  | string  | 随机生成 UUID          |
+| interviewer_token  | UUID    | `default=uuid.uuid4`           |
+| interviewee_token  | UUID    | `default=uuid.uuid4`           |
 | password           | string  | 连接密码，插入新记录时随机生成 |
 | start_time         | time    |                                |
 | length             | integer | 单位分钟，> 0，建表时默认 30   |


### PR DESCRIPTION
主要的改动：

- 将 Interviewee 从 User 中分离（不需要登录）
- free_time 使用自然语言描述，类型为 string
- Interview 表去除了 HR 和 interviewer 的 token（使用登录 token 进行验证）

问题：

- [x] `User` 是否需要 `name`（API 需要改）
- [x] `Interviewee` 的主键用 (`name`, `email`) 还是 `email`
  
  需求总结中
  > - 候选人
  >
  >   无账号，用二元组 (邮箱, 姓名) 表示；
- [x] `*_history`
  - 服务器本地文件，以某种方式命名
  - 云存储？请求的时候返回一个 302 到一次性链接