### PR TITLE
去掉路径中的 {id}

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -150,6 +150,7 @@ paths:
           $ref: '#/components/responses/Unprocessable'
   '/user/{id}':
     get:
+      deprecated: true
       tags:
         - user
       summary: 获取指定用户信息


### PR DESCRIPTION
前端获取不到用户的 ID，所以把路径里面的 `{id}` 去掉

问题：
- [x] `GET /user/{id}` 有没有必要留着
- [x] interview ID 有没有同样的问题