### PR TITLE
Return interview with token

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -386,7 +386,7 @@ paths:
                   properties:
                     id:
                       type: integer
-                      description: 本场面试的id
+                      description: 本场面试的 id
                     hr:
                       type: integer
                     interviewer:
@@ -395,7 +395,7 @@ paths:
                       type: string
                     token:
                       type: string
-                      description: 根据请求者的身份（面试官/面试者）返回与身份对应的token
+                      description: 根据请求者的身份（面试官 / 面试者）返回与身份对应的 token
                     start_time:
                       description: UTC timestamp
                       type: integer


### PR DESCRIPTION
1.数据库的`Interview`表中需要添加`hr_token`。

2.从后端获取面试信息的时候，后端需要根据请求者的身份（HR/面试官）来返回对应其身份的这场面试的`token`。