### PR TITLE
Add GET /user/{id}/assignment

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -309,7 +309,7 @@ paths:
     get:
       tags:
         - user
-      summary: 获取分配情况
+      summary: 获取分配给 HR 的面试官和面试者
       description: 获取分配情况：HR - 面试官间，HR - 面试者间。权限：current_user.role == HR && (current_user, interviewer) in HRAssignInterviewer && (current_user, interviewee) in HRAssignInterviewee
       parameters:
         - name: id
@@ -317,7 +317,7 @@ paths:
           required: true
           schema:
             type: integer
-          description: HR的id
+          description: HR 的 id
         - name: X-Token
           in: header
           schema:
@@ -332,12 +332,12 @@ paths:
                 properties:
                   interviewers:
                     type: array
-                    description: 被分配到此HR手中的面试官们的id
+                    description: 被分配到此 HR 手中的面试官们的 id
                     items:
                       type: integer
                   interviewees:
                     type: array
-                    description: 被分配到此HR手中的面试者们的email
+                    description: 被分配到此 HR 手中的面试者们的 email
                     items:
                       type: string
         '401':


### PR DESCRIPTION
需求里写的是：
Admin分配给每个HR一些面试官和面试者。
当某个HR要添加一个面试时，他要在自己手上的这些面试官和面试者中，挑选一个面试官，挑选一个面试者，指定时长。

所以在HR的“添加面试”页面，HR需要知道自己手上有哪些面试官和面试者。