### PR TITLE
Change token in get interview API

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -479,9 +479,9 @@ paths:
                       type: integer
                     interviewee:
                       type: string
-                    token:
+                    interviewer_token:
                       type: string
-                      description: 若请求者的身份为面试官或面试者，则应当是与之对应的 token，若请求者身份为 HR，则应当是空字符串
+                      description: 若请求者的身份为面试官，则应当是与之对应的 token，否则为空字符串
                     start_time:
                       description: UTC timestamp
                       type: integer


### PR DESCRIPTION
Get all interview 的接口里的 token，其实返回的就是 interviewer token，所以我和吴扬帆商量把 `token` 改成 `interviewer_token`，使得命名更清晰（HR 和管理员使用这个接口时，返回空串即可）。