### PR TITLE
Add actual length for an interview

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -488,6 +488,9 @@ paths:
                     length:
                       description: 单位：分钟
                       type: integer
+                    actual_length:
+                      description: 单位：秒
+                      type: integer
                     status:
                       type: string
                       enum:
@@ -579,6 +582,9 @@ paths:
                     type: integer
                   length:
                     description: 单位：分钟
+                    type: integer
+                  actual_length:
+                    description: 单位：秒
                     type: integer
                   status:
                     type: string

--- a/design.md
+++ b/design.md
@@ -93,6 +93,7 @@
 | password           | string  | 连接密码，插入新记录时随机生成 |
 | start_time         | time    |                                |
 | length             | integer | 单位分钟，> 0，建表时默认 30   |
+| actual_length      | integer | 单位秒，是面试的实际时长，用于回放 |
 | status             | string  | ['upcoming', 'active', 'ended'] |
 
 ### `InterviewComment`


### PR DESCRIPTION
面试的实际结束时间并不是 `length`，因为面试官可以提前结束或超时。

而回放的时候需要知道一场面试的实际长度，所以需要给 interview 表增加一个 `actual_length` 项，后端收到 SET ended 的信息（`/interview/{id}/status`）后，计算实际的长度。

这里需要把精度设成秒（`length` 的精度是分钟）。
